### PR TITLE
Add custom coercion

### DIFF
--- a/envy/scribblings/envy.scrbl
+++ b/envy/scribblings/envy.scrbl
@@ -156,7 +156,8 @@ environment. This can be done with the @racket[#:name] option.
           [maybe-type (code:line)
                       (code:line : type-id)]
           [option (code:line #:name env-var-name-expr)
-                  (code:line #:default default-expr)])]{
+                  (code:line #:default default-expr)
+                  (code:line #:coerce coerce-proc-expr)])]{
   Defines a set of variables to be initialized with values from the environment.
 
   Each @racket[name-id] is assigned the value of the environment variable with the name
@@ -178,6 +179,11 @@ environment. This can be done with the @racket[#:name] option.
     @item{@racket[Negative-Integer]}
     @item{@racket[Nonnegative-Integer]}]
 
+  If @racket[coerce-proc-expr] is provided, it must be a procedure that accepts a string and returns
+  either a value of type @racket[type-id] if provided, or a value of type @racket[String] if not provided.
+  This procedure is used to transform the environment variable's string value to a value of the proper
+  type. This overrides the default coercions for other types.
+  
   If the specified variable does not exist in the environment, @racket[name-id] is set to the value of
   @racket[default-expr]. If no @racket[default-expr] is provided, an error is raised.}
 

--- a/tests/envy/environment.rkt
+++ b/tests/envy/environment.rkt
@@ -7,7 +7,8 @@
  racket/base
  [#:opaque Environment-Variables environment-variables?]
  [current-environment-variables (Parameterof Environment-Variables)]
- [make-environment-variables (Bytes Bytes Bytes Bytes -> Environment-Variables)])
+ [make-environment-variables (->* () #:rest Bytes Environment-Variables)])
+
 
 (parameterize ([current-environment-variables (make-environment-variables #"VAR_A" #"value-a"
                                                                           #"VAR_B" #"value-b")])
@@ -25,3 +26,10 @@
   (define-environment-variable a-integer : Integer)
   (check-equal? a-boolean #t)
   (check-equal? a-integer 42))
+
+(parameterize ([current-environment-variables (make-environment-variables #"AN_OCTAL_INTEGER" #"123")])
+  (: octal-string->integer (-> String Integer))
+  (define (octal-string->integer s)
+    (cast (string->number s 8) Integer))
+  (define-environment-variable an-octal-integer : Integer #:coerce octal-string->integer)
+  (check-equal? an-octal-integer 83))


### PR DESCRIPTION
This PR adds support for a `#:coerce` keyword that allows a user to supply their own function for converting the environment variable string value into a value of the declared type. When provided, it overrides the default coercion for the declared type if there is one.

``` racket
(: octal-string->integer (-> String Integer))
(define (octal-string->integer s)
  (cast (string->number s 8) Integer))

(define-environment-variable an-octal-integer : Integer #:coerce octal-string->integer)
```

Closes #4 
